### PR TITLE
feat: autoselect payment method if only one available in the market

### DIFF
--- a/components/composite/StepPayment/CheckoutCustomerPayment.tsx
+++ b/components/composite/StepPayment/CheckoutCustomerPayment.tsx
@@ -19,11 +19,19 @@ import {
   WalletCheckbox,
 } from "./styled"
 
+import { THandleClick } from "."
+
 interface Props {
-  selectPayment: () => Promise<void>
+  selectPayment: THandleClick
+  hasTitle: boolean
+  autoSelectCallback: () => void
 }
 
-export const CheckoutCustomerPayment: React.FC<Props> = ({ selectPayment }) => {
+export const CheckoutCustomerPayment: React.FC<Props> = ({
+  selectPayment,
+  hasTitle,
+  autoSelectCallback,
+}) => {
   const { t } = useTranslation()
 
   // TemplateSaveToWalletCheckbox
@@ -87,6 +95,7 @@ export const CheckoutCustomerPayment: React.FC<Props> = ({ selectPayment }) => {
   return (
     <>
       <PaymentMethod
+        autoSelectSinglePaymentMethod={autoSelectCallback}
         activeClass="active group"
         className="payment"
         loader={PaymentSkeleton}
@@ -94,7 +103,7 @@ export const CheckoutCustomerPayment: React.FC<Props> = ({ selectPayment }) => {
         onClick={selectPayment}
       >
         <PaymentWrapper>
-          <PaymentSummaryList />
+          <PaymentSummaryList hasTitle={hasTitle} />
           <PaymentSourceContainer data-test-id="payment-source">
             <PaymentSource
               className="flex flex-col"

--- a/components/composite/StepPayment/CheckoutPayment.tsx
+++ b/components/composite/StepPayment/CheckoutPayment.tsx
@@ -9,14 +9,23 @@ import {
   PaymentDetailsWrapper,
 } from "./styled"
 
+import { THandleClick } from "."
+
 interface Props {
-  selectPayment: () => Promise<void>
+  selectPayment: THandleClick
+  hasTitle: boolean
+  autoSelectCallback: () => void
 }
 
-export const CheckoutPayment: React.FC<Props> = ({ selectPayment }) => {
+export const CheckoutPayment: React.FC<Props> = ({
+  selectPayment,
+  hasTitle,
+  autoSelectCallback,
+}) => {
   return (
     <>
       <PaymentMethod
+        autoSelectSinglePaymentMethod={autoSelectCallback}
         activeClass="active"
         className="payment group"
         loader={PaymentSkeleton}
@@ -24,7 +33,7 @@ export const CheckoutPayment: React.FC<Props> = ({ selectPayment }) => {
         onClick={selectPayment}
       >
         <PaymentWrapper data-test-id="payment-sources-container">
-          <PaymentSummaryList />
+          <PaymentSummaryList hasTitle={hasTitle} />
           <PaymentSourceContainer data-test-id="payment-source">
             <PaymentSource className="flex flex-col" loader={PaymentSkeleton}>
               <PaymentDetailsWrapper>

--- a/components/composite/StepPayment/PaymentSummaryList/index.tsx
+++ b/components/composite/StepPayment/PaymentSummaryList/index.tsx
@@ -12,7 +12,7 @@ import {
 
 import { StyledErrors } from "components/composite/OrderSummary/CouponOrGiftCard/styled"
 
-export const PaymentSummaryList = () => {
+export const PaymentSummaryList = ({ hasTitle }: { hasTitle: boolean }) => {
   const { t } = useTranslation()
   return (
     <>
@@ -21,11 +21,13 @@ export const PaymentSummaryList = () => {
           <PaymentRadioContainer>
             <StyledPaymentMethodRadioButton className="form-radio" />
           </PaymentRadioContainer>
-          <PaymentMethodNameWithStripe />
+          {hasTitle && <PaymentMethodNameWithStripe />}
         </PaymentSummaryItem>
-        <PaymentSummaryValue>
-          <PaymentMethodPrice labelFree={t("general.free")} />
-        </PaymentSummaryValue>
+        {hasTitle && (
+          <PaymentSummaryValue>
+            <PaymentMethodPrice labelFree={t("general.free")} />
+          </PaymentSummaryValue>
+        )}
       </PaymentSummary>
       <StyledErrors resource="payment_methods" />
     </>

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "commercelayer"
   ],
   "dependencies": {
-    "@commercelayer/react-components": "^3.15.0-beta.8",
+    "@commercelayer/react-components": "^3.15.0",
     "@headlessui/react": "^1.6.6",
     "@rollbar/react": "^0.11.1",
     "async-retry": "^1.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@
     client-oauth2 "^4.3.3"
     tslib "^2.3.1"
 
-"@commercelayer/react-components@^3.15.0-beta.8":
-  version "3.15.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@commercelayer/react-components/-/react-components-3.15.0-beta.8.tgz#e1a4d91312c8599df1f89966000692a0345b3425"
-  integrity sha512-UotpfbdpqVuHO8UGqElyWpVasgNpFPafWTr1hM8860En8KbFO8u0hdbLVTozvm4ov6I4Ezg8hxiwTIQaZAFFuw==
+"@commercelayer/react-components@^3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@commercelayer/react-components/-/react-components-3.15.0.tgz#d1e4291a70a9b9ef9676cf0f9cea57e5b803fe53"
+  integrity sha512-8XKifVIfV2Ok58OHmY7XgGW6CNiSeVIfWppuh+zAsQwQ4s+ZceThxqJgkV9To1qd8teqLHE9OafSUXpp/LXOtQ==
   dependencies:
     "@ac-dev/countries-service" "^1.2.0"
     "@ac-dev/states-service" "^1.1.0"


### PR DESCRIPTION
### What does this PR do?

This Feature will add the autoselection of the payment method if only one is available for the market in scope.

### How should this be manually tested?

Steps to test the autoselection:

1. Set only a payment method for a market
2. Get an sales channel access token with the market in scope
3. Open the checkout with an order
4. Complete Customer and Delivery steps
5. Payment method should be autoselected and ready to be used

### What are the relevant issues this PR belongs to

resolves #272 
