### PR TITLE
Resolve favicon 403 request error

### DIFF
--- a/components/composite/CheckoutTitle/index.tsx
+++ b/components/composite/CheckoutTitle/index.tsx
@@ -12,7 +12,7 @@ export const CheckoutHead: React.FC<Props> = (props) => {
   return (
     <Head>
       <title>{t("general.title", { companyName: props.title })}</title>
-      <link rel="shortcut icon" href={props.favicon} />
+      <link rel="icon" type="image/x-icon" href={props.favicon} />
     </Head>
   )
 }

--- a/pages/_document.page.tsx
+++ b/pages/_document.page.tsx
@@ -24,6 +24,7 @@ class AppDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
             rel="stylesheet"
           />
+          <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
 
           {process.env[
             `NEXT_PUBLIC_NEWRELIC_LOADER_CONFIG_${process.env.NEXT_PUBLIC_STAGE}`


### PR DESCRIPTION
### What does this PR do?

This PR will resolve the issue of the browser that on first load is trying to load a non existing `favicon.ico` from the root of the domain.

### What are the relevant issues this PR belongs to

- resolves #312 
